### PR TITLE
chore: add operational metadata now.yaml file

### DIFF
--- a/.omd/service/now.yaml
+++ b/.omd/service/now.yaml
@@ -1,0 +1,11 @@
+omd_service:
+  - name: name # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
+
+omd_microservice:
+  name: name # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
+  designated_dependencies: # not mandatory - omd_microservices or omd_services that the current microservice depends on.
+    - name
+    - name2
+
+# Used for tracking the repository in WBD inventory. Do not remove or alter the content.
+inventory_id: 980162270ee0cf69c2e3a0a0a87dd93d-e8e885e0931c2c609d3059f840c02b70

--- a/.omd/service/now.yaml
+++ b/.omd/service/now.yaml
@@ -1,11 +1,9 @@
 omd_service:
-  - name: name # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
+  - name: devops-toolkit # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
 
 omd_microservice:
-  name: name # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
-  designated_dependencies: # not mandatory - omd_microservices or omd_services that the current microservice depends on.
-    - name
-    - name2
+  name: github-reports # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
+
 
 # Used for tracking the repository in WBD inventory. Do not remove or alter the content.
 inventory_id: 980162270ee0cf69c2e3a0a0a87dd93d-e8e885e0931c2c609d3059f840c02b70


### PR DESCRIPTION
## Description
As a part of DTC-wide effort to improve and assign the operational metadata for GitHub repositories, we are launching this program which will help map GitHub repositories back to their omd_service and omd_microservice. This will enable us to link it back to its owner and provide other details.

In the near future, the data model used in the now.yaml will be reflected in ServiceNow. ServiceNow will receive webhook events once the yaml file is changed via a commit and will process the new file if it is committed in the main or master branch. Once this sync is enabled, ServiceNow will check if the values defined in the file are present in the CMDB - if they are not, the update is rejected and a notification will be triggered.

Henceforth teams would be able to establish a trustworthy and always up-to-date understanding of our technology ecosystem.

Please reach out in [#proj-gpso-omd](https://digital-discovery.slack.com/archives/C02L9JL6TDY) for any help or questions.

## Required Updates
The `now.yaml` file that is being added in this pull-request is only a template. The team reviewing this pull-request needs to update the YAML file following these steps.

1. Pull down the `now-yaml` branch to edit the `now.yaml` file and directory names for multi-service repos.
    - For repos with a single service, only the `now.yaml` file needs to be updated.
    - For repos with multiple services, each service must have a directory under `.omd` with the `now.yaml` file in it. (see below for example directory structure)
2. Locate this repo's service name(s) from the omd_service column in the [Temporary OMD Service Listing](https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/edit?usp=sharing&ouid=105935087614083757498&rtpof=true&sd=true)
    - If you do not see your service listed in the spreadsheet, please reach out in the [#proj-gpso-omd](https://digital-discovery.slack.com/archives/C02L9JL6TDY) channel
4. Update the `now.yaml` file's `omd_service.name` properties with the repo service name(s).
5. If the application consists of microservices, update the `omd_microservice.name` with the name of the microservice. The microservice name should be unique within an application.
6. If the microservice has other dependent services, update the `omd_microservice.designated_dependencies` property with the list.

### Example now.yaml
With dependant microservices
```yaml
omd_service:
  - name: gauth # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)

omd_microservice:
  name: gauth-broker # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
  designated_dependencies: # not mandatory - omd_microservices or omd_services that the current microservice depends on.
    - users
    - istio-ingressgateway
    - gauth-catalog
    - gauth-generic-partner
    - gauth-authn
```

Without dependant microservices
```yaml
omd_service:
  - name: apple-dtc # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)

omd_microservice:
  name: dplus-ios # mandatory - predefined in the Temporary OMD Service Listing doc (https://docs.google.com/spreadsheets/d/1FNbvrvN4OhiQBhxw9XkGDcMoaPZQZKxV/)
```

### Example Multi-Service Directory Structure
Example of a repo that represents 3 services
```
.omd
  - service-a
    - now.yaml
  - service-b
    - now.yaml
  - service-c
    - now.yaml
```
